### PR TITLE
fix: filter to show only language news for locals

### DIFF
--- a/blocks/news/news.js
+++ b/blocks/news/news.js
@@ -5,6 +5,7 @@ import {
   updateExternalLinks,
   fetchPlaceholders,
   fetchGraphQL,
+  isFr,
 } from '../../scripts/scripts.js';
 
 function filterHasItems(filter, block) {
@@ -172,7 +173,13 @@ async function getLocalArticles() {
       };
     }
     return null;
-  }).filter((item) => item !== null);
+  }).filter((item) => item !== null).filter((item) => {
+    if (isFr()) {
+      return item.url.startsWith('/fr/');
+    }
+
+    return !item.url.startsWith('/fr/');
+  });
   return newsItems;
 }
 


### PR DESCRIPTION
See https://adobe-dx-support.slack.com/archives/C03GXBSC72T/p1682513299742859

Test URLs:
- Before: https://main--pga-presidents-cup--hlxsites.hlx.page/news
- After: https://fr-news--pga-presidents-cup--hlxsites.hlx.page/news
